### PR TITLE
One way to make LinkClock init stuff static class members

### DIFF
--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -50,6 +50,7 @@
 #include "SC_Lock.h"
 
 #include "SC_Clock.hpp"
+#include "SC_Ableton_Link.hpp"
 
 #include <boost/sync/semaphore.hpp>
 #include <boost/sync/support/std_chrono.hpp>
@@ -233,12 +234,6 @@ using monotonic_clock = std::conditional<std::chrono::high_resolution_clock::is_
 
 static std::chrono::high_resolution_clock::time_point hrTimeOfInitialization;
 
-#ifdef SC_ABLETON_LINK
-  class LinkClock {
-    public:
-      static void Init();
-  };
-#endif
 SCLANG_DLLEXPORT_C void schedInit()
 {
 	using namespace std::chrono;

--- a/lang/LangPrimSource/PyrSched.cpp
+++ b/lang/LangPrimSource/PyrSched.cpp
@@ -234,14 +234,17 @@ using monotonic_clock = std::conditional<std::chrono::high_resolution_clock::is_
 static std::chrono::high_resolution_clock::time_point hrTimeOfInitialization;
 
 #ifdef SC_ABLETON_LINK
-	void initLink();
+  class LinkClock {
+    public:
+      static void Init();
+  };
 #endif
 SCLANG_DLLEXPORT_C void schedInit()
 {
 	using namespace std::chrono;
 	hrTimeOfInitialization     = high_resolution_clock::now();
 #ifdef SC_ABLETON_LINK
-	initLink();
+  LinkClock::Init();
 #endif
 
 	syncOSCOffsetWithTimeOfDay();

--- a/lang/LangPrimSource/SC_Ableton_Link.cpp
+++ b/lang/LangPrimSource/SC_Ableton_Link.cpp
@@ -1,44 +1,5 @@
 #ifdef SC_ABLETON_LINK
-
-#include "PyrKernel.h"
-#include "PyrSched.h"
-#include "GC.h"
-#include "PyrPrimitive.h"
-#include "PyrSymbol.h"
-
-#include "SCBase.h"
-#include "SC_Clock.hpp"
-
-#include <ableton/Link.hpp>
-
-class LinkClock : public TempoClock
-{
-public:
-	LinkClock(VMGlobals *inVMGlobals, PyrObject* inTempoClockObj,
-				double inTempo, double inBaseBeats, double inBaseSeconds);
-
-	~LinkClock() {}
-
-	void SetTempoAtBeat(double inTempo, double inBeats);
-	void SetTempoAtTime(double inTempo, double inSeconds);
-	void SetAll(double inTempo, double inBeats, double inSeconds);
-	double BeatsToSecs(double beats) const;
-	double SecsToBeats(double secs) const;
-
-	void SetQuantum(double quantum);
-        double GetLatency();
-        void SetLatency(double latency);
-	std::size_t NumPeers() const { return mLink.numPeers(); }
-
-  static void Init();
-  static std::chrono::microseconds GetInitTime() { return LinkClock::mInitTime; }
-
-private:
-	ableton::Link mLink;
-	double mQuantum;
-	double mLatency;
-  static std::chrono::microseconds mInitTime;
-};
+#include "SC_Ableton_Link.hpp"
 
 std::chrono::microseconds LinkClock::mInitTime;
 

--- a/lang/LangPrimSource/SC_Ableton_Link.hpp
+++ b/lang/LangPrimSource/SC_Ableton_Link.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+#ifdef SC_ABLETON_LINK
+
+#include "PyrKernel.h"
+#include "PyrSched.h"
+#include "GC.h"
+#include "PyrPrimitive.h"
+#include "PyrSymbol.h"
+
+#include "SCBase.h"
+#include "SC_Clock.hpp"
+
+#include <ableton/Link.hpp>
+
+class LinkClock : public TempoClock
+{
+public:
+	LinkClock(VMGlobals *inVMGlobals, PyrObject* inTempoClockObj,
+				double inTempo, double inBaseBeats, double inBaseSeconds);
+
+	~LinkClock() {}
+
+	void SetTempoAtBeat(double inTempo, double inBeats);
+	void SetTempoAtTime(double inTempo, double inSeconds);
+	void SetAll(double inTempo, double inBeats, double inSeconds);
+	double BeatsToSecs(double beats) const;
+	double SecsToBeats(double secs) const;
+
+	void SetQuantum(double quantum);
+        double GetLatency();
+        void SetLatency(double latency);
+	std::size_t NumPeers() const { return mLink.numPeers(); }
+
+  static void Init();
+  static std::chrono::microseconds GetInitTime() { return LinkClock::mInitTime; }
+
+private:
+	ableton::Link mLink;
+	double mQuantum;
+	double mLatency;
+  static std::chrono::microseconds mInitTime;
+};
+
+#endif // SC_ABLETON_LINK


### PR DESCRIPTION
Not sure this is all that much nicer, but if the init logic is to all be contained in `LinkClock`, I think it needs to go something like this.

